### PR TITLE
Fix mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 CC=cc
+BISON=bison
 CFLAGS=-g -Wall $(shell pkg-config --cflags libedit)
 LDFLAGS=$(shell pkg-config --libs libedit)
 
 all: stutter
+
+# run make macosx_deps to get dependencies necessary for mac os x build
+with_brew: BISON=$(shell brew --prefix bison)/bin/bison
+with_brew: stutter
 
 stutter: lex.yy.o stutter.tab.o sv.o parse.o main.o hash.o env.o builtins.o utils.o
 	$(CC) -o stutter lex.yy.o stutter.tab.o sv.o parse.o main.o hash.o env.o builtins.o utils.o $(LDFLAGS)
@@ -14,7 +19,7 @@ lex.yy.o: stutter.tab.h stutter.l sv.h
 stutter.tab.h: stutter.tab.o
 
 stutter.tab.o: stutter.y sv.h
-	bison -d stutter.y
+	$(BISON) -d stutter.y
 	$(CC) $(CFLAGS) -c stutter.tab.c
 
 sv.o: sv.c sv.h env.h
@@ -37,6 +42,9 @@ builtins.o: builtins.c env.h sv.h
 
 utils.o: utils.c utils.h
 	$(CC) $(CFLAGS) -c utils.c
+
+macosx_deps:
+	brew install bison
 
 clean:
 	rm -f lex.yy.[ch] stutter.tab.[ch] stutter *.o

--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ Or you can use the repl by specifying no arguments:
     stutter> ^D
     Bye!
 
+### Mac OS X build
+
+You should have `homebrew` installed.
+
+    make macosx_deps
+    make with_brew

--- a/main.c
+++ b/main.c
@@ -1,4 +1,9 @@
-#include <readline.h>
+#ifdef __APPLE__
+    #include <editline/readline.h>
+#else
+    #include <editline/readline.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/main.c
+++ b/main.c
@@ -1,7 +1,7 @@
 #ifdef __APPLE__
     #include <editline/readline.h>
 #else
-    #include <editline/readline.h>
+    #include <readline.h>
 #endif
 
 #include <stdio.h>


### PR DESCRIPTION
Mac OS X has outdated bison version out of the box and it's own readline implementation with different headers.

This pull request adds necessary changes to build stutter on mac