### PR TITLE
replace lambda with hex sequence to solve compile errors in #6

### DIFF
--- a/builtins.c
+++ b/builtins.c
@@ -30,7 +30,7 @@ Builtin_init(void)
         { "def",          Builtin_def },
         { "cons",         Builtin_cons },
         { "list",         Builtin_list },
-        { u8"λ",          Builtin_lambda },
+        { "\xce\xbb",     Builtin_lambda },
         { "lambda",       Builtin_lambda },
         { "macroexpand-1",Builtin_macroexpand_1 },
         { "macroexpand",  Builtin_macroexpand },


### PR DESCRIPTION
This pull request replaces u8"λ" char with escape sequence to please c compiler on mac os x to fix #6 